### PR TITLE
Fix link in release notes for 19.09

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -140,7 +140,7 @@ New features include:
 * More data download options
 * Minor bug fixes throughout the platform
 
-For more details, check our [blog](https://blog.opentargets.org/2019/11/28/open-targets-platform-release-19-11-is-out).
+For more details, check our [blog](https://blog.opentargets.org/2019/09/24/open-targets-platform-release-19-09-is-out/).
 
 ## Release 3.13 \(2019-06-27\)
 


### PR DESCRIPTION
The 19.09 release notes linked to the 19.11 blog post.